### PR TITLE
Update _index.md

### DIFF
--- a/website/content/getting_started/_index.md
+++ b/website/content/getting_started/_index.md
@@ -51,7 +51,8 @@ cmake -G Ninja ../llvm \
 # Optionally, using ASAN/UBSAN can find bugs early in development, enable with:
 # -DLLVM_USE_SANITIZER="Address;Undefined" 
 # Optionally, enabling integration tests as well
-# -DMLIR_INCLUDE_INTEGRATION_TESTS=ON
+# and enable execution engine since it is used by tests 
+# -DMLIR_INCLUDE_INTEGRATION_TESTS=ON -DMLIR_ENABLE_EXECUTION_ENGINE=ON
 cmake --build . --target check-mlir
 ```
 


### PR DESCRIPTION
Document the need to specify -DMLIR_ENABLE_EXECUTION_ENGINE=ON if -DMLIR_INCLUDE_INTEGRATION_TESTS=ON is used when configuring the build. Else mlir-cpu-runner that is used by mlir tests would not be built resulting in test failures.